### PR TITLE
run small jobs with small slurm allocation

### DIFF
--- a/config/setonix.config
+++ b/config/setonix.config
@@ -25,9 +25,12 @@ process {
   queueSize = 1024
   cache = 'lenient'
   stageInMode = 'symlink'
-  
+
     withName: 'checkInputs' {
-	    executor = 'local'
+	    executor = 'slurm'
+        cpus = 1
+        time = '10m'
+        memory = '1.GB'
     }
 
     withName: 'manta' {
@@ -38,8 +41,12 @@ process {
     }
 
     withName: 'rehead_manta' {
-        executor = 'local'
+	    executor = 'slurm'
+        cpus = 1
+        time = '10m'
+        memory = '1.GB'
     }
+
     withName: 'smoove' {
         executor = 'slurm'
         disk = '400.GB'
@@ -56,7 +63,10 @@ process {
     } 
 
     withName: 'rehead_tiddit' {
-        executor = 'local'
+        executor = 'slurm'
+        cpus = 1
+        time = '10m'
+        memory = '1.GB'
     }
 
     withName: 'tiddit_cov' {
@@ -67,13 +77,16 @@ process {
     }
 
     withName: 'survivor_summary' {
-        executor = 'local'
+        executor = 'slurm'
+        cpus = 1
+        time = '10m'
+        memory = '1.GB'
     }
 
-withName: 'annotsv' {
-    executor = 'slurm'
-    cpus = 1
-    time = '1h'
-    memory = '10.GB'
+    withName: 'annotsv' {
+        executor = 'slurm'
+        cpus = 1
+        time = '1h'
+        memory = '10.GB'
     }
 }


### PR DESCRIPTION
running small jobs in local mode causes naming issues, and isn't strictly needed on Pawsey anyway.