### PR TITLE
Add gdata to gadi config

### DIFF
--- a/config/gadi.config
+++ b/config/gadi.config
@@ -15,7 +15,7 @@ process {
 	cache = 'lenient'
 	stageInMode = 'symlink'
 	project = "${params.pbs_account}"
-	storage = "scratch/${params.pbs_account}"
+	storage = "scratch/${params.pbs_account}+gdata/${params.pbs_account}"
 	disk = '30.GB'
 
     withName: 'checkInputs' {

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -67,7 +67,11 @@ process {
 }
 
     withName: 'survivor_merge' {
-        executor = 'local'
+        executor = 'pbspro'
+        queue = 'normal'
+        cpus = 1
+        time = '1h'
+        memory = '10.GB'
 }
 
     withName: 'survivor_summary' {


### PR DESCRIPTION
Encountering issue exposing `g/data` partition when executing workflow from Tower. Have attempted to workaround by providing `-lstorage=scratch/<project>+gdata/<project>,` as Head job submit options in Tower compute environment set up but resolved config shows this is not being applied. 

This PR adds gdata to gadi.config:

```
storage = "scratch/${params.pbs_account}+gdata/${params.pbs_account}"
```