### PR TITLE
Gadi local jobs failing to access 10Gb memory

### DIFF
--- a/config/gadi.config
+++ b/config/gadi.config
@@ -75,10 +75,18 @@ process {
 }
 
     withName: 'survivor_summary' {
-        executor = 'local'
+        executor = 'pbspro'
+        queue = 'normal'
+        cpus = 1
+        time = '1h'
+        memory = '10.GB'
 }
 
     withName: 'annotsv' {
-        executor = 'local'
+        executor = 'pbspro'
+        queue = 'normal'
+        cpus = 1
+        time = '1h'
+        memory = '10.GB'
 
 }}


### PR DESCRIPTION
When running a larger cohort >10 samples, jobs local to execution cannot access required memory of 10Gb on Gadi. Survivor merge, summary, annotsv need to be submitted to normal queue to avoid this. 