### PR TITLE
Remove harcoded `GRCh38` version for `AnnotSv`

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -90,6 +90,8 @@ Optional Arguments:
 	--survivorSize		    Minimum size (bp) event to report (default 40bp).
 
 	--annotsvDir		    Full path to the directory housing the prepared AnnotSV directory.
+	
+	--genomeBuild		    Genome version from annotsvDir downloaded files (default: GRCh37).
 
 	--annotsvMode		    Specify full, split, or both for AnnotSV output mode (default: both).
 

--- a/main.nf
+++ b/main.nf
@@ -43,6 +43,7 @@ Workflow run parameters
  strand agreement : ${params.survivorStrand}
  minMerge size    : ${params.survivorSize}
  annotsvDir       : ${params.annotsvDir}
+ genomeBuild      : ${params.genomeBuild}
  annotsvMode      : ${params.annotsvMode}
  outDir           : ${params.outDir}
  workDir          : ${workflow.workDir}

--- a/modules/annotsv.nf
+++ b/modules/annotsv.nf
@@ -34,7 +34,7 @@ process annotsv {
 		-annotationsDir ${params.annotsvDir} \
 		-bedtools bedtools -bcftools bcftools \
 		-annotationMode ${mode} \
-		-genomeBuild GRCh38 \
+		-genomeBuild ${params.genomeBuild} \
 		-includeCI 1 \
 		-overwrite 1 \
 		-outputFile ${outputFile} ${extraArgs}

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,7 @@ params {
   survivorStrand	  	= 1
   survivorSize	    	= 40
   annotsvDir	      	= false
+  genomeBuild         = 'GRCh37'
   annotsvMode	      	= 'both'
   extraMantaFlags   	= false
   extraSmooveFlags  	= false
@@ -30,7 +31,7 @@ params {
   extraTidditSvFlags	= false
   extraAnnotsvFlags 	= false
   gadi_account       	= false
-  setonix_account     	= false
+  setonix_account     = false
   whoami            	= false
 }
 


### PR DESCRIPTION
Hi thanks for this awesome open source tool! 🥇 

My teammate @ddomenico and I noticed that `AnnotSV` runs a harcoded version of `GRCh38`, even though the README instructions provide commands to download reference files like the Exomiser data in version `hg19`.

https://github.com/Sydney-Informatics-Hub/Germline-StructuralV-nf/blob/886570876219720448fee3319d3815875466722b/modules/annotsv.nf#L32-L41

Using `GRCh38` or  `GRCh37` should be configurable through a `param` . I added the `param.genomeBuild` to annotation removing the hardcoded `GRCh38`. And set `GRCh37` as default to match the README example.
