### PR TITLE
DEV: Configure pipeline for hg38 runs and reference updates

### DIFF
--- a/config/gadi.config
+++ b/config/gadi.config
@@ -38,8 +38,11 @@ process {
         queue = 'normal'
 	    disk = '50.GB'
         cpus = 4
-        time = '6h'
         memory = '16.GB'
+        // walltime scales with read pairs that map to different chr 
+        time = { 6.h * task.attempt }
+        errorStrategy = { task.exitStatus in [137, 143] ? 'retry' : 'terminate' }
+        maxRetries = 1
     }
 
     withName: 'rehead_smoove' {

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -15,7 +15,7 @@ process {
 	cache = 'lenient'
 	stageInMode = 'symlink'
 	project = "${params.gadi_account}"
-	storage = "scratch/${params.gadi_account}+gdata/${params.gadi_account}"
+	storage = params.storage_account ?: "scratch/${params.gadi_account}+gdata/${params.gadi_account}"
 	disk = '30.GB'
 
     withName: 'checkInputs' {

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -41,7 +41,7 @@ process {
         memory = '16.GB'
         // walltime scales with read pairs that map to different chr 
         time = { 6.h * task.attempt }
-        errorStrategy = { task.exitStatus in [137, 143] ? 'retry' : 'terminate' }
+        errorStrategy = { task.exitStatus in [137, 143] ? 'retry' : 'ignore' }
         maxRetries = 1
     }
 
@@ -53,8 +53,10 @@ process {
         executor = 'pbspro'
         queue = 'normal'
         cpus = 6
-        time = '2h'
-        memory = '24.GB'
+        memory = { 24.GB * task.attempt }
+        time = { 2.h * task.attempt }
+        errorStrategy = { task.exitStatus in [137, 143] ? 'retry' : 'terminate' }
+        maxRetries = 3
     }
 
     withName: 'rehead_tiddit' {

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -24,9 +24,9 @@ process {
     withName: 'manta' {
         executor = 'pbspro'
         queue = 'normal'
-        cpus = 10
-        time = '3h'
-        memory = '40.GB'
+        cpus = 12
+        time = '2h'
+        memory = '48.GB'
 }
 
     withName: 'rehead_manta' {
@@ -36,10 +36,10 @@ process {
     withName: 'smoove' {
         executor = 'pbspro'
         queue = 'normal'
-	disk = '400.GB'
+	    disk = '50.GB'
         cpus = 4
-        time = '3h'
-        memory = '190.GB'
+        time = '6h'
+        memory = '16.GB'
 }
 
     withName: 'rehead_smoove' {
@@ -49,10 +49,10 @@ process {
     withName: 'tiddit_sv' {
         executor = 'pbspro'
         queue = 'normal'
-        cpus = 4
-        time = '3h'
-        memory = '40.GB'
-} 
+        cpus = 6
+        time = '2h'
+        memory = '24.GB'
+}
 
     withName: 'rehead_tiddit' {
         executor = 'local'
@@ -62,8 +62,8 @@ process {
         executor = 'pbspro'
         queue = 'normal'
         cpus = 1
-        time = '3h'
-        memory = '10.GB'
+        time = '1h'
+        memory = '4.GB'
 }
 
     withName: 'survivor_merge' {
@@ -71,7 +71,7 @@ process {
         queue = 'normal'
         cpus = 1
         time = '1h'
-        memory = '10.GB'
+        memory = '4.GB'
 }
 
     withName: 'survivor_summary' {
@@ -79,14 +79,14 @@ process {
         queue = 'normal'
         cpus = 1
         time = '1h'
-        memory = '10.GB'
+        memory = '4.GB'
 }
 
     withName: 'annotsv' {
         executor = 'pbspro'
         queue = 'normal'
-        cpus = 1
+        cpus = 4
         time = '1h'
-        memory = '10.GB'
+        memory = '16.GB'
 
 }}

--- a/config/gadi.config
+++ b/config/gadi.config
@@ -19,19 +19,19 @@ process {
 	disk = '30.GB'
 
     withName: 'checkInputs' {
-	executor = 'local'
-}
+	    executor = 'local'
+    }
     withName: 'manta' {
         executor = 'pbspro'
         queue = 'normal'
         cpus = 12
         time = '2h'
         memory = '48.GB'
-}
+    }
 
     withName: 'rehead_manta' {
         executor = 'local'
-}
+        }
 
     withName: 'smoove' {
         executor = 'pbspro'
@@ -40,11 +40,11 @@ process {
         cpus = 4
         time = '6h'
         memory = '16.GB'
-}
+    }
 
     withName: 'rehead_smoove' {
         executor = 'local'
-}
+    }
 
     withName: 'tiddit_sv' {
         executor = 'pbspro'
@@ -52,11 +52,11 @@ process {
         cpus = 6
         time = '2h'
         memory = '24.GB'
-}
+    }
 
     withName: 'rehead_tiddit' {
         executor = 'local'
-}
+    }
 
     withName: 'tiddit_cov' {
         executor = 'pbspro'
@@ -64,7 +64,7 @@ process {
         cpus = 1
         time = '1h'
         memory = '4.GB'
-}
+    }
 
     withName: 'survivor_merge' {
         executor = 'pbspro'
@@ -72,7 +72,7 @@ process {
         cpus = 1
         time = '1h'
         memory = '4.GB'
-}
+    }
 
     withName: 'survivor_summary' {
         executor = 'pbspro'
@@ -80,7 +80,7 @@ process {
         cpus = 1
         time = '1h'
         memory = '4.GB'
-}
+    }
 
     withName: 'annotsv' {
         executor = 'pbspro'
@@ -88,5 +88,5 @@ process {
         cpus = 4
         time = '1h'
         memory = '16.GB'
-
-}}
+    }
+}

--- a/main.nf
+++ b/main.nf
@@ -92,7 +92,7 @@ Optional Arguments:
 
 	--annotsvDir		    Full path to the directory housing the prepared AnnotSV directory.
 	
-	--genomeBuild		    Genome version from annotsvDir downloaded files (default: GRCh37).
+	--genomeBuild		    Genome version from annotsvDir downloaded files, GRCh37 or GRCh38 (default: GRCh38).
 
 	--annotsvMode		    Specify full, split, or both for AnnotSV output mode (default: both).
 
@@ -111,6 +111,8 @@ HPC accounting arguments:
         --whoami                    HPC user name (Setonix or Gadi HPC)
 
         --gadi_account              Project accounting code for NCI Gadi (e.g. aa00)
+
+        --storage_account           NCI Gadi PBS storage mounts for tasks (e.g. 'scratch/aa00+gdata/if89'), needed when the reference or AnnotSV data live under another project
 
         --setonix_account           Project accounting code for Pawsey Setonix (e.g. name1234)
 """.stripIndent()

--- a/modules/annotsv.nf
+++ b/modules/annotsv.nf
@@ -2,6 +2,7 @@
 process annotsv {
 	debug false
 	publishDir "${params.outDir}/${sampleID}/annotsv", mode: 'copy'
+	container 'quay.io/biocontainers/annotsv:3.5.10--hdfd78af_0'
 
 	input:
 	tuple val(sampleID), path(mergedVCF)

--- a/modules/manta.nf
+++ b/modules/manta.nf
@@ -2,6 +2,7 @@
 process manta {
 	debug false
 	publishDir "${params.outDir}/${sampleID}", mode: 'copy'
+	container 'quay.io/biocontainers/mulled-v2-40295ae41112676b05b649e513fe7000675e9b84:0b4be2c719f99f44df34be7b447b287bb7f86e01-0'
 
 	input:
 	tuple val(sampleID), file(bam), file(bai)
@@ -59,8 +60,9 @@ process manta {
 
 // rehead manta SV vcf for merging 
 process rehead_manta {
-	debug false 
+	debug false
 	publishDir "${params.outDir}/${sampleID}/manta", mode: 'copy'
+	container 'quay.io/biocontainers/bcftools:1.15.1--hfe4b78e_1'
 
 	input:
 	tuple val(sampleID), path(manta_diploid_convert)

--- a/modules/manta.nf
+++ b/modules/manta.nf
@@ -47,8 +47,9 @@ process manta {
 	mv manta/results/variants/diploidSV.vcf.gz.tbi \
 		manta/Manta_${sampleID}.diploidSV.vcf.gz.tbi
 	
-	# convert multiline inversion BNDs from manta vcf to single line
-	convertInversion.py \$(which samtools) ${params.ref} \
+	# Use patched script to parse contigs correctly e.g. HLA-DQB1*06:01:01:88
+	# See comment in scripts/convertInversion_patched.py
+	python2 ${projectDir}/scripts/convertInversion_patched.py \$(which samtools) ${params.ref} \
 		manta/Manta_${sampleID}.diploidSV.vcf.gz \
 		> manta/Manta_${sampleID}.diploidSV_converted.vcf
 

--- a/modules/smoove.nf
+++ b/modules/smoove.nf
@@ -2,6 +2,7 @@
 process smoove {
 	debug false
 	publishDir "${params.outDir}/${sampleID}", mode: 'copy'
+	container 'brentp/smoove:v0.2.7'
 
 	input:
 	tuple val(sampleID), file(bam), file(bai)
@@ -30,8 +31,9 @@ process smoove {
 
 // rehead smoove genotyped vcf for merging 
 process rehead_smoove {
-	debug false 
+	debug false
 	publishDir "${params.outDir}/${sampleID}/smoove", mode: 'copy'
+	container 'quay.io/biocontainers/bcftools:1.15.1--hfe4b78e_1'
 
 	input:
 	tuple val(sampleID), path(smoove_geno)

--- a/modules/survivor_merge.nf
+++ b/modules/survivor_merge.nf
@@ -2,6 +2,7 @@
 process survivor_merge {
 	debug false
 	publishDir "${params.outDir}/${sampleID}/survivor", mode: 'copy'
+	container 'quay.io/biocontainers/survivor:1.0.7--hd03093a_2'
 		
 	input:
 	//tuple val(sampleID), path(mergelist)

--- a/modules/survivor_summary.nf
+++ b/modules/survivor_summary.nf
@@ -2,6 +2,7 @@
 process survivor_summary {
 	debug false
 	publishDir "${params.outDir}/${sampleID}/survivor", mode: 'copy'
+	container 'quay.io/biocontainers/survivor:1.0.7--hd03093a_2'
 
 	input:
 	tuple val(sampleID), path(mergedVCF)
@@ -25,6 +26,7 @@ process survivor_summary {
 process survivor_venn {
 	debug false
 	publishDir "${params.outDir}/${sampleID}/survivor", mode: 'copy'
+	container 'quay.io/biocontainers/survivor:1.0.7--hd03093a_2'
 
 	input:
 	tuple val(sampleID), path(mergedVCF)

--- a/modules/tiddit_cov.nf
+++ b/modules/tiddit_cov.nf
@@ -2,6 +2,7 @@
 process tiddit_cov {
 	debug false
 	publishDir "${params.outDir}/${sampleID}/tiddit", mode: 'copy'
+	container 'quay.io/biocontainers/tiddit:3.6.0--py310hc2b7f4b_0'
 	
 	input:
 	tuple val(sampleID), file(bam), file(bai)

--- a/modules/tiddit_sv.nf
+++ b/modules/tiddit_sv.nf
@@ -2,6 +2,7 @@
 process tiddit_sv {
 	debug false
 	publishDir "${params.outDir}/${sampleID}/tiddit", mode: 'copy'
+	container 'quay.io/biocontainers/tiddit:3.6.0--py310hc2b7f4b_0'
 
 	input:
 	tuple val(sampleID), file(bam), file(bai)
@@ -38,7 +39,7 @@ process tiddit_sv {
 process rehead_tiddit {
 	debug false 
 	publishDir "${params.outDir}/${sampleID}/tiddit", mode: 'copy'
-	container "${params.bcftools__container}"
+	container 'quay.io/biocontainers/bcftools:1.15.1--hfe4b78e_1'
 
 	input:
 	tuple val(sampleID), path(tiddit_vcf)

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,7 +23,7 @@ params {
   survivorStrand	  	= 1
   survivorSize	    	= 40
   annotsvDir	      	= false
-  genomeBuild         = 'GRCh37'
+  genomeBuild         = 'GRCh38'
   annotsvMode	      	= 'both'
   extraMantaFlags   	= false
   extraSmooveFlags  	= false
@@ -31,6 +31,7 @@ params {
   extraTidditSvFlags	= false
   extraAnnotsvFlags 	= false
   gadi_account       	= false
+  storage_account     = false
   setonix_account     = false
   whoami            	= false
 }
@@ -107,7 +108,7 @@ withName: 'survivor_summary' {
 withName: 'annotsv' {
 	cpus = 1
 	memory = 10.GB
-  container = 'sydneyinformaticshub/annotsv:3.2.1'
+  container = 'quay.io/biocontainers/annotsv:3.5.10--hdfd78af_0'
   }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,68 +45,10 @@ singularity {
 // Fail a task if any command returns non-zero exit code
 shell = ['/bin/bash', '-euo', 'pipefail']
 
-// Resources for each process
-// default run resource parameters
-process {
-
-withName: 'smoove' {
-	cpus    = 4
-	memory  = 40.GB
-  container	= 'brentp/smoove:v0.2.7'
-  }
-
-withName: 'rehead_smoove' {
-  container	= 'quay.io/biocontainers/bcftools:1.15.1--hfe4b78e_1'
-  }
-
-withName: 'manta' {
-	cpus    = 10
-	memory = 40.GB
-  container	= 'quay.io/biocontainers/mulled-v2-40295ae41112676b05b649e513fe7000675e9b84:0b4be2c719f99f44df34be7b447b287bb7f86e01-0'
-  }
-
-withName: 'rehead_manta' {
-  container	= 'quay.io/biocontainers/bcftools:1.15.1--hfe4b78e_1'
-  }
-
-withName: 'tiddit_sv' {
-	cpus = 4
-	memory = 40.GB
-  container	= 'quay.io/biocontainers/tiddit:3.6.0--py310hc2b7f4b_0'
-  }
-
-withName: 'rehead_tiddit' {
-  container	= 'quay.io/biocontainers/bcftools:1.15.1--hfe4b78e_1'
-}
-
-withName: 'tiddit_cov' {
-	cpus = 1
-	memory = 10.GB
-  container	= 'quay.io/biocontainers/tiddit:3.6.0--py310hc2b7f4b_0'
-  }
-
-withName: 'survivor_merge' {
-	cpus = 1
-	memory = 10.GB
-  container	= 'quay.io/biocontainers/survivor:1.0.7--hd03093a_2'
-  }
-
-withName: 'survivor_summary' {
-	cpus = 1
-	memory = 10.GB
-  container	= 'quay.io/biocontainers/survivor:1.0.7--hd03093a_2'
-  }
-
-withName: 'annotsv' {
-	cpus = 1
-	memory = 10.GB
-  container = 'quay.io/biocontainers/annotsv:3.5.10--hdfd78af_0'
-  }
-}
-
 // Job profiles
-// Placed after the default `process` block so profile-specific resources
-// (e.g. config/gadi.config) override these defaults rather than the reverse.
+// Per-process resources/executor live in the profile config files (e.g. config/gadi.config).
+// Container images are hardcoded in each process body in modules/*.nf, so they are never
+// dropped by config resource overrides and require no config wiring here.
 profiles {
   local		{ includeConfig "config/local.config" }
   nimbus	{ includeConfig "config/nimbus.config" }

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,14 +42,6 @@ singularity {
     autoMounts		= true
     }
 
-// Job profiles
-profiles {
-  local		{ includeConfig "config/local.config" }
-  nimbus	{ includeConfig "config/nimbus.config" }
-  gadi		{ includeConfig "config/gadi.config" }
-  setonix	{ includeConfig "config/setonix.config" }
-}
-
 // Fail a task if any command returns non-zero exit code
 shell = ['/bin/bash', '-euo', 'pipefail']
 
@@ -112,7 +104,15 @@ withName: 'annotsv' {
   }
 }
 
-
+// Job profiles
+// Placed after the default `process` block so profile-specific resources
+// (e.g. config/gadi.config) override these defaults rather than the reverse.
+profiles {
+  local		{ includeConfig "config/local.config" }
+  nimbus	{ includeConfig "config/nimbus.config" }
+  gadi		{ includeConfig "config/gadi.config" }
+  setonix	{ includeConfig "config/setonix.config" }
+}
 
 // Define timestamp, to avoid overwriting existing trace
 def timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
@@ -138,5 +138,5 @@ trace {
 	enabled = true
 	overwrite = true
   file = "${params.outDir}/runInfo/GermlineStructuralV_trace_${timestamp}.txt"
-  fields = 'process,name,status,queue,realtime,cpus,%cpu,memory,%mem,rss,env'
+  fields = 'process,name,status,queue,realtime,cpus,%cpu,memory,%mem,rss,peak_rss,peak_vmem,env'
 }

--- a/scripts/convertInversion_patched.py
+++ b/scripts/convertInversion_patched.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python2
+#
+# Manta - Structural Variant and Indel Caller
+# Copyright (c) 2013-2019 Illumina, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+#
+# SIH patch: The Manta container expects contig names to have exactly one `:`
+# e.g. `chr:pos`. This fails when fails when there are more than one `:` which
+# throws `ValueError: too many values to unpack`, e.g. `HLA-DQB1*06:01:01:88`
+# This script patches this by usign rsplit to parse the chr:pos correctly.
+
+
+import sys
+import gzip
+from io import BufferedReader
+from subprocess import check_output
+from os import path
+from os.path import exists
+
+
+class VcfRecord:
+
+    def __init__(self, inline):
+        tokens = inline.strip().split('\t')
+
+        self.chr = tokens[0]
+        self.pos = int(tokens[1])
+        self.vid = tokens[2]
+        self.ref = tokens[3]
+        self.alt = tokens[4]
+        self.qual = tokens[5]
+        self.filter = tokens[6]
+        self.info = tokens[7].split(';')
+        self.others = "\t".join(tokens[8:])
+
+        # Create a dictionary for INFO
+        self.infoDict ={}
+        for infoItem in self.info:
+            items = infoItem.split('=')
+            if len(items) == 1:
+                self.infoDict[items[0]] = True
+            elif len(items) > 1:
+                self.infoDict[items[0]] = items[1]
+
+        self.isINV3 = False
+        self.isINV5 = False
+        self.mateChr = ""
+        self.matePos = -1
+
+
+    def checkInversion(self):
+
+        def getMateInfo(splitChar):
+            items = self.alt.split(splitChar)
+            [self.mateChr, matePos] = items[1].rsplit(':', 1)
+            self.matePos = int(matePos)
+
+        if self.alt.startswith('['):
+            getMateInfo('[')
+            if self.mateChr == self.chr:
+                self.isINV5 = True
+        elif self.alt.endswith(']'):
+            getMateInfo(']')
+            if self.mateChr == self.chr:
+                self.isINV3 = True
+
+
+    def makeLine(self):
+        infoStr = ";".join(self.info)
+
+        self.line = "\t".join((self.chr,
+                               str(self.pos),
+                               self.vid,
+                               self.ref,
+                               self.alt,
+                               self.qual,
+                               self.filter,
+                               infoStr,
+                               self.others
+                           ))+"\n"
+
+
+def scanVcf(vcfFile):
+
+    invMateDict = {}
+
+    if vcfFile.endswith('gz'):
+        gzfp = gzip.open(vcfFile, 'rb')
+        fpVcf = BufferedReader(gzfp)
+    else:
+        fpVcf = open(vcfFile, 'rb')
+
+    for line in fpVcf:
+        if line[0] == '#':
+            continue
+
+        vcfRec = VcfRecord(line)
+        vcfRec.checkInversion()
+        if vcfRec.isINV3 or vcfRec.isINV5:
+            if vcfRec.vid in invMateDict:
+                # update mate INFO
+                invMateDict[vcfRec.vid] = vcfRec.infoDict
+            else:
+                mateId = vcfRec.infoDict["MATEID"]
+                invMateDict[mateId] = ""
+
+    return invMateDict
+
+
+def getReference(samtools, refFasta, chrom, start, end):
+    region = "%s:%d-%d" % (chrom, start, end)
+    samtoolsOut = check_output([samtools, "faidx", refFasta, region])
+    refSeq = ""
+    for seq in samtoolsOut.split('\n'):
+        if not seq.startswith(">"):
+            refSeq += seq
+
+    return refSeq.upper()
+
+
+def writeLines(lines):
+    for line in lines:
+        sys.stdout.write(line)
+
+
+def convertInversions(samtools, refFasta, vcfFile, invMateDict):
+    isHeaderInfoAdded = False
+    isHeaderAltAdded = False
+    lineBuffer = []
+    bufferedChr = ""
+    bufferedPos = -1
+
+    if vcfFile.endswith('gz'):
+        gzfp = gzip.open(vcfFile, 'rb')
+        fpVcf = BufferedReader(gzfp)
+    else:
+        fpVcf = open(vcfFile, 'rb')
+
+    for line in fpVcf:
+        if line.startswith('#'):
+            if (not isHeaderInfoAdded) and line.startswith("##FORMAT="):
+                sys.stdout.write("##INFO=<ID=INV3,Number=0,Type=Flag,Description=\"Inversion breakends open 3' of reported location\">\n")
+                sys.stdout.write("##INFO=<ID=INV5,Number=0,Type=Flag,Description=\"Inversion breakends open 5' of reported location\">\n")
+                isHeaderInfoAdded = True
+
+            if (not isHeaderAltAdded) and line.startswith("##ALT="):
+                sys.stdout.write("##ALT=<ID=INV,Description=\"Inversion\">\n")
+                isHeaderAltAdded = True
+
+            sys.stdout.write(line)
+            continue
+
+        vcfRec = VcfRecord(line)
+
+        # skip mate record
+        if vcfRec.vid in invMateDict:
+            continue
+
+        vcfRec.checkInversion()
+        if vcfRec.isINV3 or vcfRec.isINV5:
+            if vcfRec.isINV5:
+                # adjust POS for INV5
+                vcfRec.pos -= 1
+                vcfRec.matePos -= 1
+                vcfRec.ref = getReference(samtools, refFasta,
+                                          vcfRec.chr, vcfRec.pos, vcfRec.pos)
+
+            # update manta ID
+            vidSuffix = vcfRec.vid.split("MantaBND")[1]
+            idx = vidSuffix.rfind(':')
+            vcfRec.vid = "MantaINV%s" % vidSuffix[:idx]
+
+            # symbolic ALT
+            vcfRec.alt = "<INV>"
+
+            # add END
+            infoEndStr = "END=%d" % vcfRec.matePos
+
+            newInfo = [infoEndStr]
+            for infoItem in vcfRec.info:
+                if infoItem.startswith("SVTYPE"):
+                    # change SVTYPE
+                    newInfo.append("SVTYPE=INV")
+                    # add SVLEN
+                    infoSvLenStr = "SVLEN=%d" % (vcfRec.matePos-vcfRec.pos)
+                    newInfo.append(infoSvLenStr)
+
+                elif infoItem.startswith("CIPOS"):
+                    newInfo.append(infoItem)
+
+                    # set CIEND
+                    isImprecise = "IMPRECISE" in vcfRec.infoDict
+                    # for imprecise calls, set CIEND to the mate breakpoint's CIPOS
+                    if isImprecise:
+                        mateId = vcfRec.infoDict["MATEID"]
+                        mateInfoDict = invMateDict[mateId]
+                        infoCiEndStr = "CIEND=%s" % (mateInfoDict["CIPOS"])
+                        newInfo.append(infoCiEndStr)
+                    # for precise calls, set CIEND w.r.t HOMLEN
+                    else:
+                        if "HOMLEN" in vcfRec.infoDict:
+                            infoCiEndStr = "CIEND=-%s,0" % vcfRec.infoDict["HOMLEN"]
+                            newInfo.append(infoCiEndStr)
+
+                elif infoItem.startswith("HOMSEQ"):
+                    # update HOMSEQ for INV5
+                    if vcfRec.isINV5:
+                        cipos = vcfRec.infoDict["CIPOS"].split(',')
+                        homSeqStart = vcfRec.pos + int(cipos[0]) + 1
+                        homSeqEnd = vcfRec.pos + int(cipos[1])
+                        refSeq = getReference(samtools, refFasta, vcfRec.chr,
+                                              homSeqStart, homSeqEnd)
+                        infoHomSeqStr = "HOMSEQ=%s" % refSeq
+                        newInfo.append(infoHomSeqStr)
+                    else:
+                        newInfo.append(infoItem)
+
+                # skip BND-specific tags
+                elif (infoItem.startswith("MATEID") or
+                      infoItem.startswith("BND_DEPTH") or
+                      infoItem.startswith("MATE_BND_DEPTH")):
+                    continue
+
+                # update event ID
+                elif infoItem.startswith("EVENT"):
+                    eidSuffix = vcfRec.infoDict["EVENT"].split("MantaBND")[1]
+                    idx = vidSuffix.rfind(':')
+                    infoEventStr = "EVENT=MantaINV%s" % eidSuffix[:idx]
+                    newInfo.append(infoEventStr)
+
+                # apply all other tags
+                else:
+                    newInfo.append(infoItem)
+
+            # add INV3/INV5 tag
+            if vcfRec.isINV3:
+                newInfo.append("INV3")
+            elif vcfRec.isINV5:
+                newInfo.append("INV5")
+
+            vcfRec.info = newInfo
+
+        vcfRec.makeLine()
+
+        # make sure the vcf is sorted in genomic order
+        if (not vcfRec.chr == bufferedChr) or (vcfRec.pos > bufferedPos):
+            if lineBuffer:
+                writeLines(lineBuffer)
+
+            lineBuffer = [vcfRec.line]
+            bufferedChr = vcfRec.chr
+            bufferedPos = vcfRec.pos
+        elif vcfRec.pos < bufferedPos:
+            lineBuffer.insert(0, vcfRec.line)
+        else:
+            lineBuffer.append(vcfRec.line)
+
+    if lineBuffer:
+        writeLines(lineBuffer)
+
+
+
+if __name__=='__main__':
+
+    usage = "convertInversion.py <samtools path> <reference fasta> <vcf file>\n"
+    if len(sys.argv) <= 3:
+        sys.stderr.write(usage)
+        sys.exit(1)
+
+    samtools = sys.argv[1]
+    refFasta = sys.argv[2]
+    vcfFile = sys.argv[3]
+
+    for inputFile in [samtools, refFasta, vcfFile]:
+        if not(exists(inputFile)):
+            errMsg = ('File %s does not exist.'
+                      % inputFile)
+            sys.stderr.write(errMsg + '\nProgram exits.')
+            sys.exit(1)
+
+    invMateDict = scanVcf(vcfFile)
+    convertInversions(samtools, refFasta, vcfFile, invMateDict)


### PR DESCRIPTION
- annotsv: bump container to biocontainers annotsv 3.5.10 to match the Annotations_Human_3.5 data package (bioconda recipe bundles bedtools + bcftools, so the -bedtools/-bcftools calls still resolve)
- use exomiser version 2406, pinned by [annotsv](https://github.com/lgmgeo/AnnotSV/blob/master/Makefile#L48)
- default genomeBuild GRCh37 -> GRCh38. GR used needs to be the same version as that generated the bams (i.e. for manta compatability)
- gadi: add storage_account param so the PBS -l storage mount can be passed in (e.g. 'scratch/er01+gdata/if89') instead of hardcoding gdata/<account>

SU and walltime comparisons, before v after:

| Task | Old cpu/mem | Old wall | New cpu/mem | New wall | Δwall | Old SU | New SU | ΔSU |
|---|---|---|---|---|---|---|---|---|
| manta (1) | 10c/40G | 58.5m | 12c/48G | 46.6m | −20% | 19.50 | 18.65 | −4% |
| manta (2) | 10c/40G | 37.7m | 12c/48G | 29.2m | −23% | 12.57 | 11.68 | −7% |
| manta (3) | 10c/40G | 41.5m | 12c/48G | 30.2m | −27% | 13.82 | 12.07 | −13% |
| smoove (2) | 4c/40G | 32.0m | 4c/16G | 31.0m | −3% | 10.67 | 4.13 | −61% |
| smoove (3) | 4c/40G | 31.8m | 4c/16G | 30.0m | −6% | 10.58 | 4.00 | −62% |
| tiddit_sv (1) | 4c/40G | 70.2m | 6c/24G | 60.9m | −13% | 23.41 | 12.18 | −48% |
| tiddit_sv (2) | 4c/40G | 57.9m | 6c/24G | 36.3m | −37% | 19.31 | 7.26 | −62% |
| tiddit_sv (3) | 4c/40G | 55.6m | 6c/24G | 40.9m | −26% | 18.54 | 8.18 | −56% |
| tiddit_cov (1) | 1c/10G | 27.9m | 1c/4G | 27.5m | −1% | 2.33 | 0.92 | −61% |
| tiddit_cov (2) | 1c/10G | 30.4m | 1c/4G | 29.2m | −4% | 2.53 | 0.97 | −62% |
| tiddit_cov (3) | 1c/10G | 32.6m | 1c/4G | 33.3m | +2% | 2.71 | 1.11 | −59% |
| **Total (comparable)** | | **476.1m** | | **395.1m** | **−17%** | **135.97** | **81.15** | **−40%** |


TODO:
- [ ] Update version in metadata
- [ ] Add changelog